### PR TITLE
rename Chatroom list to Channels for US Demo App

### DIFF
--- a/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Chatroom/ChatroomListViewController.m
+++ b/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Chatroom/ChatroomListViewController.m
@@ -51,7 +51,7 @@
     }
     [[EMClient sharedClient].roomManager addDelegate:self delegateQueue:nil];
     // Uncomment the following line to preserve selection between presentations.
-    self.title = NSLocalizedString(@"title.chatroomlist",@"chatroom list");
+    self.title = NSLocalizedString(@"title.chatroomlist",@"channels");
     
     // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;

--- a/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Chatroom/MyChatroomListViewController.m
+++ b/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Chatroom/MyChatroomListViewController.m
@@ -208,7 +208,7 @@ static NSString *kOnceJoinedChatroomsPattern = @"OnceJoinedChatrooms_%@";
     if (indexPath.section == 0) {
         switch (indexPath.row) {
             case 0:
-                cell.textLabel.text = NSLocalizedString(@"title.chatroomlist",@"chatroom list");
+                cell.textLabel.text = NSLocalizedString(@"title.chatroomlist",@"channels");
                 cell.imageView.image = [UIImage imageNamed:@"group_joinpublicgroup"];
                 break;
             default:

--- a/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Contacts/ContactListViewController.m
+++ b/ChatDemo-UI3.0/ChatDemo-UI3.0/Class/Contacts/ContactListViewController.m
@@ -206,7 +206,7 @@
         }
         else if (indexPath.row == 2) {
             cell.avatarView.image = [UIImage imageNamed:@"EaseUIResource.bundle/group"];
-            cell.titleLabel.text = NSLocalizedString(@"title.chatroomlist",@"chatroom list");
+            cell.titleLabel.text = NSLocalizedString(@"title.chatroomlist",@"channels");
         }
         else if (indexPath.row == 3) {
             cell.avatarView.image = [UIImage imageNamed:@"EaseUIResource.bundle/group"];

--- a/ChatDemo-UI3.0/ChatDemo-UI3.0/en.lproj/Localizable.strings
+++ b/ChatDemo-UI3.0/ChatDemo-UI3.0/en.lproj/Localizable.strings
@@ -293,7 +293,7 @@
 "title.groupApply" = "Group Notification";
 "title.groupSubjectChanging" = "Change group name";
 "title.groupSearchMessage" = "Search Message from History";
-"title.chatroomlist" = "Chatroom List";
+"title.chatroomlist" = "Channels";
 "title.robotlist" = "Robot List";
 "title.profile" = "Profile";
 


### PR DESCRIPTION
美国版本的Demo App，为了便于用户理解，将Chatroom list暂时更名为Channels